### PR TITLE
JAVASERVERFACES-4074 - Correct use of getExternalContext().isSecure() missed by JAVASERVERFACES-3531

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/context/flash/ELFlash.java
+++ b/jsf-ri/src/main/java/com/sun/faces/context/flash/ELFlash.java
@@ -999,7 +999,23 @@ public class ELFlash extends Flash {
             if (null != (val = toSet.getMaxAge())) {
                 properties.put("maxAge", val);
             }
-            if (context.getExternalContext().isSecure()) {
+            // Bug 18611757 / JAVASERVERFACES-4074: only use extContext.isSecure() if we
+            // absolutely must.  For example, if we are in a portlet environment.
+            boolean isSecure = false;
+            Object request = extContext.getRequest();
+            if (request instanceof ServletRequest) {
+                isSecure = ((ServletRequest)request).isSecure();
+            } else {
+                try {
+                    isSecure = extContext.isSecure();
+                } catch (UnsupportedOperationException uoe) {
+                    if (LOGGER.isLoggable(Level.SEVERE)) {
+                        LOGGER.log(Level.SEVERE, "ExternalContext {0} does not implement isSecure().  Please implement this per the JSF 2.1 specification.",
+                                new Object [] { extContext });
+                    }
+                }
+            }
+            if (isSecure) {
                 properties.put("secure", Boolean.TRUE);
             } else if (null != (val = toSet.getSecure())) {
                 properties.put("secure", val);


### PR DESCRIPTION
JAVASERVERFACES-4074 - Correct use of getExternalContext().isSecure() missed by JAVASERVERFACES-3531
