### PR TITLE
https://java.net/jira/browse/JAVASERVERFACES-4217 Always render jsf.js as a component

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/facelets/util/Classpath.java
+++ b/jsf-ri/src/main/java/com/sun/faces/facelets/util/Classpath.java
@@ -232,6 +232,11 @@ public final class Classpath {
             prefix = join(split, true);
             String end = join(split, false);
             int p = urlString.lastIndexOf(end);
+
+            if (p < 0) {
+                return;
+            }
+
             urlString = urlString.substring(0, p);
             for (String cur : PREFIXES_TO_EXCLUDE) {
                 if (urlString.startsWith(cur)) {


### PR DESCRIPTION
Rendering jsf.js as a component invokes the renderkit and allows libraries to
easily change or override its rended markup.