### PR TITLE
Fix Issue #4265 - New keywords not available in f:ajax

### DIFF
--- a/impl/src/main/java/javax/faces/component/behavior/AjaxBehavior.java
+++ b/impl/src/main/java/javax/faces/component/behavior/AjaxBehavior.java
@@ -805,25 +805,15 @@ public class AjaxBehavior extends ClientBehaviorBase {
         if (value.charAt(0) == '@') {
             // These are very common, so we use shared copies
             // of these collections instead of re-creating.
-            List<String> list;
-
             if (ALL.equals(value)) {
-                list = ALL_LIST;
+                return ALL_LIST;
             } else if (FORM.equals(value)){
-                list = FORM_LIST;
+                return FORM_LIST;
             } else if (THIS.equals(value)) {
-                list = THIS_LIST; 
+                return THIS_LIST; 
             } else if (NONE.equals(value)) {
-                list = NONE_LIST;
-            } else {
-                // RELEASE_PENDING i18n ;
-                throw new FacesException(value
-                                     + " : Invalid id keyword specified for '"
-                                     + propertyName
-                                     + "' attribute");
+                return NONE_LIST;
             }
-            
-            return list;
         }
          
         return Collections.singletonList(value);


### PR DESCRIPTION
This fixes #4265. The fix is fairly minimal. Theoretically, depending on how often some of the new keywords are used (i.e. @parent), added additional static arrays might be useful.