### PR TITLE
Modified the ViewHandlingStrategies for JSP and Facelet to allow recursive calls

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
+++ b/jsf-ri/src/main/java/com/sun/faces/application/view/FaceletViewHandlingStrategy.java
@@ -424,6 +424,7 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
             LOGGER.fine("Rendering View: " + viewToRender.getViewId());
         }
 
+        WriteBehindStateWriter existingStateWriter = WriteBehindStateWriter.getCurrentInstance();
         WriteBehindStateWriter stateWriter = null;
         try {
             // Only build the view if this view has not yet been built.
@@ -514,6 +515,9 @@ public class FaceletViewHandlingStrategy extends ViewHandlingStrategy {
         } finally {
             if (stateWriter != null) {
                 stateWriter.release();
+            }
+            if (existingStateWriter != null) {
+                WriteBehindStateWriter.setCurrentInstance(existingStateWriter);
             }
         }
     }

--- a/jsf-ri/src/main/java/com/sun/faces/application/view/WriteBehindStateWriter.java
+++ b/jsf-ri/src/main/java/com/sun/faces/application/view/WriteBehindStateWriter.java
@@ -181,6 +181,10 @@ final class WriteBehindStateWriter extends Writer {
     public static WriteBehindStateWriter getCurrentInstance() {
         return CUR_WRITER.get();
     }
+    
+    public static void setCurrentInstance(WriteBehindStateWriter writer) {
+        CUR_WRITER.set(writer);
+    }
 
 
     /**


### PR DESCRIPTION
WriteBehindStateWriter is kept in a ThreadLocal, presumably to allow interoperability between the JSP and Facelet ViewHandlingStrategy implementations. However, this has the unfortunate side effect of preventing recursive calls to view rendering within the same thread.

Adding a setCurrentInstance method to WriteBehindStateWriter and a try-finally to the JSP and Facelet ViewHandlingStrategy's renderView methods allows us to account for potential preexisting WriteBehindStateWriters in the current Thread.