### PR TITLE
Fix for Issue #4281

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/facelets/compiler/CompilationManager.java
+++ b/jsf-ri/src/main/java/com/sun/faces/facelets/compiler/CompilationManager.java
@@ -336,11 +336,14 @@ final class CompilationManager {
                 this.finishUnit();
             } else {
                 t.endTag();
+                if (t.isClosed()) {
+                    this.finishUnit();
+                }
                 return;
             }
+            unit = this.currentUnit();
         }
 
-        unit = this.currentUnit();
         if (unit instanceof TagUnit) {
             TagUnit t = (TagUnit) unit;
             if (t instanceof TrimmedTagUnit) {


### PR DESCRIPTION
The issue is caused because raw HTML tags are closed and popped the next time a JSF tag is popped; however, this causes popNamespaces to fail if a namespace was defined on a raw HTML tag. I fixed this by adding a finishUnit call when t.endTag() closes the last tag in a block of text.

In case there is some issue with my fix, an alternative fix is to copy the if statement from lines 335-337 into popNamespaces (and the necessary variable declarations).