### PR TITLE
Fix for HtmlResponseWriter breaking conditional comments (#4288)

### DIFF
--- a/jsf-ri/src/main/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriter.java
+++ b/jsf-ri/src/main/java/com/sun/faces/renderkit/html_basic/HtmlResponseWriter.java
@@ -869,7 +869,7 @@ public class HtmlResponseWriter extends ResponseWriter {
         writer.write("<!--");
         String str = comment.toString();
         ensureTextBufferCapacity(str);
-        HtmlUtils.writeText(writer, true, true, buffer, str, textBuffer);
+        HtmlUtils.writeText(writer, true, true, false, buffer, str, textBuffer);
         writer.write("-->");
 
     }


### PR DESCRIPTION
This fix adds an additional, "escapeSyntax" parameter to the HtmlUtils#writeText(...) methods.

The fix is actually quite small - most of the additions are from creating copies of those methods with the original parameters in order to not break backwards compatibility.

Note: The fix does not actually involve deleting code - I just had to fix the indenting when I added an if statement for the new "escapeSyntax" parameter.

P.S. If anybody can come up with a better variable name than, "escapeSyntax", I would very much appreciate it.