### PR TITLE
Fix referenced namespace

### DIFF
--- a/jsf-ri/conf/share/composite.taglib.xml
+++ b/jsf-ri/conf/share/composite.taglib.xml
@@ -131,7 +131,7 @@ would make that file accessible like this.</p>
       xmlns:h="http://xmlns.jcp.org/jsf/html"<br />
       xmlns:f="http://xmlns.jcp.org/jsf/core"<br />
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"<br />
-      xmlns:ez="<i><b>http://domain.com/path/namespace</b></i>"&gt;<br />
+      xmlns:ez="<i><b>http://domain.com/path</b></i>"&gt;<br />
 ...<br />
 </code></pre>
 

--- a/jsf-ri/conf/share/composite.tld
+++ b/jsf-ri/conf/share/composite.tld
@@ -133,7 +133,7 @@ would make that file accessible like this.</p>
       xmlns:h="http://xmlns.jcp.org/jsf/html"<br />
       xmlns:f="http://xmlns.jcp.org/jsf/core"<br />
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"<br />
-      xmlns:ez="<i><b>http://domain.com/path/namespace</b></i>"&gt;<br />
+      xmlns:ez="<i><b>http://domain.com/path</b></i>"&gt;<br />
 ...<br />
 </code></pre>
 


### PR DESCRIPTION
Referenced namespace shall match exactly the one defined in /facelet-taglib/namespace,
otherwise following happens:

> This page calls for XML namespace http://domain.com/path/namespace
> declared with prefix ez but no taglibrary exists for that namespace.

Fixes #1149 (closed, not fixed)

Locally built with accompanying change: https://github.com/pzygielo/mojarra/commit/df42d71059ffc9b89ce2bf23193b42ed639b2ce0.